### PR TITLE
fix: handle out-of-range weather window in clear-days API

### DIFF
--- a/src/app/_components/SearchForm.tsx
+++ b/src/app/_components/SearchForm.tsx
@@ -53,6 +53,7 @@ export function SearchForm({ onSearch }: SearchFormProps) {
     const [isCalendarOpen, setIsCalendarOpen] = useState<boolean>(false);
     const [isFetchingWeather, setIsFetchingWeather] = useState<boolean>(false);
     const [weatherError, setWeatherError] = useState<string | null>(null);
+    const [weatherNotice, setWeatherNotice] = useState<string | null>(null);
     const [annotation, setAnnotation] = useState<string | null>(null);
     const [validationMessage, setValidationMessage] = useState<string | null>(null);
 
@@ -95,6 +96,7 @@ export function SearchForm({ onSearch }: SearchFormProps) {
     useEffect(() => {
         weatherAbortControllerRef.current?.abort();
         setWeatherError(null);
+        setWeatherNotice(null);
         setWeatherWindow([]);
         setDateRange({ start: null, end: null });
         if (!selectedPrefecture) {
@@ -151,12 +153,19 @@ export function SearchForm({ onSearch }: SearchFormProps) {
                     start: typeof payload?.startDate === 'string' ? payload.startDate : null,
                     end: typeof payload?.endDate === 'string' ? payload.endDate : null,
                 });
+
+                if (payload?.availability === 'out_of_supported_range' && typeof payload?.message === 'string') {
+                    setWeatherNotice(payload.message);
+                } else {
+                    setWeatherNotice(null);
+                }
             } catch (error) {
                 if (controller.signal.aborted) {
                     return;
                 }
                 const message = error instanceof Error ? error.message : '晴れ予報の取得に失敗しました';
                 setWeatherError(`晴れ予報の取得に失敗しました: ${message}`);
+                setWeatherNotice(null);
                 setWeatherWindow([]);
             } finally {
                 if (!controller.signal.aborted) {
@@ -220,15 +229,21 @@ export function SearchForm({ onSearch }: SearchFormProps) {
         if (weatherError) {
             return weatherError;
         }
+        if (weatherNotice) {
+            return weatherNotice;
+        }
         if (!hasSelectableDays) {
             return '15日以内に晴れの予報が見つかりませんでした。';
         }
         return '晴れの日だけ選択できます。';
-    }, [selectedPrefecture, isFetchingWeather, weatherError, hasSelectableDays]);
+    }, [selectedPrefecture, isFetchingWeather, weatherError, weatherNotice, hasSelectableDays]);
 
     const calendarStatusClass = useMemo(() => {
         if (weatherError) {
             return 'text-rose-500';
+        }
+        if (weatherNotice) {
+            return 'text-amber-600';
         }
         if (!selectedPrefecture || isFetchingWeather) {
             return 'text-slate-500';
@@ -237,7 +252,7 @@ export function SearchForm({ onSearch }: SearchFormProps) {
             return 'text-amber-600';
         }
         return 'text-slate-500';
-    }, [weatherError, selectedPrefecture, isFetchingWeather, hasSelectableDays]);
+    }, [weatherError, weatherNotice, selectedPrefecture, isFetchingWeather, hasSelectableDays]);
 
     const handlePrefectureChange = (event: ChangeEvent<HTMLSelectElement>) => {
         const value = event.target.value;

--- a/src/app/api/prefecture/clear-days/__tests__/route.test.ts
+++ b/src/app/api/prefecture/clear-days/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="jest" />
+
+const getDailyWeatherSummariesRangeMock = jest.fn();
+const getPrefectureCoordinatesMock = jest.fn();
+
+jest.mock('@/lib/server/open_metro_api_client', () => ({
+    getDailyWeatherSummariesRange: (...args: unknown[]) => getDailyWeatherSummariesRangeMock(...args),
+}));
+
+jest.mock('@/lib/server/prefecture_geocode', () => ({
+    getPrefectureCoordinates: (...args: unknown[]) => getPrefectureCoordinatesMock(...args),
+}));
+
+describe('GET /api/prefecture/clear-days', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        process.env = originalEnv;
+    });
+
+    it('today が許容上限を超える場合は 200 + days:[] を返し、外部APIを呼ばない', async () => {
+        jest.setSystemTime(new Date('2026-04-04T00:00:00.000Z'));
+
+        process.env.OPEN_METEO_ALLOWED_START_DATE_MIN = '2025-07-10';
+        process.env.OPEN_METEO_ALLOWED_START_DATE_MAX = '2025-10-26';
+
+        getPrefectureCoordinatesMock.mockReturnValue({ latitude: 34.6913, longitude: 135.1830 });
+
+        const { GET } = await import('../route');
+
+        const request = new Request('http://localhost/api/prefecture/clear-days?prefecture=%E5%85%B5%E5%BA%AB%E7%9C%8C');
+        const response = await GET(request);
+        const payload = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(payload).toEqual({
+            prefecture: '兵庫県',
+            startDate: null,
+            endDate: null,
+            days: [],
+            availability: 'out_of_supported_range',
+            message: '現在の提供期間外のため晴れ予報を表示できません。',
+        });
+        expect(getDailyWeatherSummariesRangeMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/api/prefecture/clear-days/route.ts
+++ b/src/app/api/prefecture/clear-days/route.ts
@@ -4,8 +4,8 @@ import { getPrefectureCoordinates } from '@/lib/server/prefecture_geocode';
 
 // TODO: WINDOWS_DAYSだけで実現する。
 const WINDOW_DAYS = 15;
-const PUBLIC_ALLOWED_MIN = process.env.NEXT_PUBLIC_OPEN_METEO_ALLOWED_START_DATE_MIN ?? '2025-07-10';
-const PUBLIC_ALLOWED_MAX = process.env.NEXT_PUBLIC_OPEN_METEO_ALLOWED_START_DATE_MAX ?? '2025-10-26';
+const PUBLIC_ALLOWED_MIN = process.env.NEXT_PUBLIC_OPEN_METEO_ALLOWED_START_DATE_MIN;
+const PUBLIC_ALLOWED_MAX = process.env.NEXT_PUBLIC_OPEN_METEO_ALLOWED_START_DATE_MAX;
 const SERVER_ALLOWED_MIN = process.env.OPEN_METEO_ALLOWED_START_DATE_MIN ?? PUBLIC_ALLOWED_MIN;
 const SERVER_ALLOWED_MAX = process.env.OPEN_METEO_ALLOWED_START_DATE_MAX ?? PUBLIC_ALLOWED_MAX;
 
@@ -17,34 +17,40 @@ interface ClearDaysResponseDay {
     temperatureMin: number;
 }
 
-function toIsoDate(date: Date): string {
+function toUtcIsoDate(date: Date): string {
     return date.toISOString().slice(0, 10);
 }
 
-function computeWindowBounds(): { start: string; end: string } {
-    const today = new Date();
-    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+function addDaysUtcIso(isoDate: string, days: number): string {
+    const date = new Date(`${isoDate}T00:00:00Z`);
+    date.setUTCDate(date.getUTCDate() + days);
+    return toUtcIsoDate(date);
+}
 
-    const minAllowed = new Date(`${SERVER_ALLOWED_MIN}T00:00:00Z`);
-    const maxAllowed = new Date(`${SERVER_ALLOWED_MAX}T00:00:00Z`);
+function maxIso(a: string, b: string): string {
+    return a > b ? a : b;
+}
 
-    const windowStartDate = todayStart > minAllowed ? todayStart : minAllowed;
-    const tentativeEnd = new Date(windowStartDate);
-    tentativeEnd.setDate(tentativeEnd.getDate() + (WINDOW_DAYS - 1));
+function minIso(a: string, b: string): string {
+    return a < b ? a : b;
+}
 
-    const windowEndDate = tentativeEnd < maxAllowed ? tentativeEnd : maxAllowed;
+function computeWindowBounds(): { start: string | null; end: string | null; isOutOfSupportedRange: boolean } {
+    const todayIso = toUtcIsoDate(new Date());
 
-    if (windowEndDate < windowStartDate) {
-        return {
-            start: toIsoDate(windowStartDate),
-            end: toIsoDate(windowStartDate),
-        };
+    if (SERVER_ALLOWED_MAX && todayIso > SERVER_ALLOWED_MAX) {
+        return { start: null, end: null, isOutOfSupportedRange: true };
     }
 
-    return {
-        start: toIsoDate(windowStartDate),
-        end: toIsoDate(windowEndDate),
-    };
+    const start = SERVER_ALLOWED_MIN ? maxIso(todayIso, SERVER_ALLOWED_MIN) : todayIso;
+    const tentativeEnd = addDaysUtcIso(start, WINDOW_DAYS - 1);
+    const end = SERVER_ALLOWED_MAX ? minIso(tentativeEnd, SERVER_ALLOWED_MAX) : tentativeEnd;
+
+    if (end < start) {
+        return { start: null, end: null, isOutOfSupportedRange: true };
+    }
+
+    return { start, end, isOutOfSupportedRange: false };
 }
 
 export async function GET(request: Request) {
@@ -62,14 +68,16 @@ export async function GET(request: Request) {
         }
 
         const windowBounds = computeWindowBounds();
-        const { start, end } = windowBounds;
+        const { start, end, isOutOfSupportedRange } = windowBounds;
 
-        if (start > end) {
+        if (isOutOfSupportedRange || !start || !end) {
             return NextResponse.json({
                 prefecture,
-                startDate: start,
-                endDate: end,
+                startDate: null,
+                endDate: null,
                 days: [] as ClearDaysResponseDay[],
+                availability: 'out_of_supported_range',
+                message: '現在の提供期間外のため晴れ予報を表示できません。',
             });
         }
 

--- a/src/lib/server/open_metro_api_client.ts
+++ b/src/lib/server/open_metro_api_client.ts
@@ -10,10 +10,8 @@ const HOURLY_VARIABLES = 'weather_code,is_day,temperature_2m';
 const MAX_FETCH_RETRIES = 3;
 const RETRY_DELAY_MS = 1_000;
 
-// Open‑Meteo が許容する start_date の範囲（API の仕様 / 応答に基づく）
-// 注意: 将来的に変わる可能性があるため、必要なら環境変数や設定で上書きできるようにする。
-const OPEN_METEO_ALLOWED_START_DATE_MIN = process.env.OPEN_METEO_ALLOWED_START_DATE_MIN ?? '2025-07-10';
-const OPEN_METEO_ALLOWED_START_DATE_MAX = process.env.OPEN_METEO_ALLOWED_START_DATE_MAX ?? '2025-10-26';
+const OPEN_METEO_ALLOWED_START_DATE_MIN = process.env.OPEN_METEO_ALLOWED_START_DATE_MIN;
+const OPEN_METEO_ALLOWED_START_DATE_MAX = process.env.OPEN_METEO_ALLOWED_START_DATE_MAX;
 
 export interface DailyWeatherSummary {
     /** 対象日 (ISO 8601, YYYY-MM-DD) */
@@ -40,12 +38,13 @@ export async function getDailyWeatherSummary(
 
     const targetDateIso = normaliseDate(date);
 
-    // Open-Meteo の仕様により start_date は利用可能なレンジに限定される。
-    // ここで明示的にバリデーションを行い、クライアント側で早期にエラーを返す。
     const minAllowed = OPEN_METEO_ALLOWED_START_DATE_MIN;
     const maxAllowed = OPEN_METEO_ALLOWED_START_DATE_MAX;
-    if (targetDateIso < minAllowed || targetDateIso > maxAllowed) {
-        throw new RangeError(`start_date must be within ${minAllowed} and ${maxAllowed}`);
+    if (minAllowed && targetDateIso < minAllowed) {
+        throw new RangeError(`start_date must be on or after ${minAllowed}`);
+    }
+    if (maxAllowed && targetDateIso > maxAllowed) {
+        throw new RangeError(`start_date must be on or before ${maxAllowed}`);
     }
 
     const responses = await fetchWeatherWithRetry({
@@ -87,8 +86,11 @@ export async function getDailyWeatherSummariesRange(
 
     const minAllowed = OPEN_METEO_ALLOWED_START_DATE_MIN;
     const maxAllowed = OPEN_METEO_ALLOWED_START_DATE_MAX;
-    if (startIso < minAllowed || endIso > maxAllowed) {
-        throw new RangeError(`date range must be within ${minAllowed} and ${maxAllowed}`);
+    if (minAllowed && startIso < minAllowed) {
+        throw new RangeError(`date range start must be on or after ${minAllowed}`);
+    }
+    if (maxAllowed && endIso > maxAllowed) {
+        throw new RangeError(`date range end must be on or before ${maxAllowed}`);
     }
 
     const responses = await fetchWeatherWithRetry({


### PR DESCRIPTION
## Summary
- clear-days API の期間計算を UTC ISO ベースに変更
- 提供期間外の場合は 200 + `days: []` と `availability: out_of_supported_range` を返すように変更
- UI で提供期間外通知をエラー表示と分離して表示
- 回帰防止として route テストを追加（today > maxAllowed で外部API未呼び出し）

## Why
本番で許容日付レンジ超過時に 400 が返り、都道府県選択で晴れ予報が取得できなくなる問題を恒久対応するため。

## Test
- `src/app/api/prefecture/clear-days/__tests__/route.test.ts`
- `src/lib/server/__tests__/open_metro_api_client.unit.test.ts`

Closes #7
